### PR TITLE
"Collaborators" and "Colleagues", not "Customers"

### DIFF
--- a/src/components/blog-posts.js
+++ b/src/components/blog-posts.js
@@ -19,30 +19,39 @@ class BlogPosts extends React.Component {
   }
 
   render () {
-    const renderPosts = posts => posts.map(post => (
-      <div key={post.created} className="cell large-auto">
-        <span className="post-date">{moment(post.created).format('LL')}</span>
-        <h1 className="header-medium">
-          <a href={post.url}>{post.title}</a>
-        </h1>
-        <p>
-          <a href={post.url}>
-            <img src={post.image} alt="blog post" />
-          </a>
-        </p>
-        <p className="post-excerpt">{post.description}</p>
-        <a
-          className="button small "
-          href={post.url}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+    const renderPosts = posts => posts.map((post) => {
+      let postImage = null;
+      if (post.image) {
+        postImage = (
+          <p>
+            <a href={post.url}>
+              <img src={post.image} alt="blog post" />
+            </a>
+          </p>
+        );
+      }
+
+      return (
+        <div key={post.created} className="cell large-auto">
+          <span className="post-date">{moment(post.created).format('LL')}</span>
+          <h1 className="header-medium">
+            <a href={post.url}>{post.title}</a>
+          </h1>
+          {postImage}
+          <p className="post-excerpt">{post.description}</p>
+          <a
+            className="button small "
+            href={post.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Read more
-          {' '}
-          <FontAwesome name="external-link" />
-        </a>
-      </div>
-    ));
+            {' '}
+            <FontAwesome name="external-link" />
+          </a>
+        </div>
+      );
+    });
 
     const { posts } = this.state;
 

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -26,7 +26,7 @@ const TemplateWrapper = ({ children }) => (
         rel="stylesheet"
         href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
       />
-      <script type="text/javascript" src="js/track.js" />
+      <script type="text/javascript" src="/js/track.js" />
       <script
         type="text/javascript"
         src="https://cdn.trackjs.com/releases/current/tracker.js"

--- a/src/components/project.js
+++ b/src/components/project.js
@@ -17,7 +17,7 @@ const Project = (props) => {
       customer = (
         <div>
           <hr />
-          <h6>Customer</h6>
+          <h6>Built with</h6>
           {project.customer}
         </div>
       );

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -83,8 +83,8 @@ const AboutPage = () => (
               <div className="media-object-section">
                 <h4>Build With, Not For</h4>
                 <p>
-                  Planning Labs is a design partner, working closely with its
-                  customers in visioning and agile development. Customers are
+                  Planning Labs is a design partner, working closely with our
+                  colleagues in visioning and agile development. Collaborators are
                   expected to provide resources for the duration of a product
                   build, and will be heavily involved in sprint planning,
                   testing and acceptance.
@@ -342,7 +342,7 @@ const AboutPage = () => (
               establishing a service delivery unit within the Information
               Technology Division. Planning Labs’ mission would be to build
               lightweight impactful tools with the agency’s divisions as
-              clients, and to be open, vocal, and inclusive about the modern
+              collaborators, and to be open, vocal, and inclusive about the modern
               technologies and processes used.
             </p>
           </div>

--- a/src/pages/process.js
+++ b/src/pages/process.js
@@ -11,7 +11,7 @@ const ProcessPage = () => (
     <div id="main" className="main">
       <Hero
         title="Our Process"
-        tagline="Planning Labs projects are chosen through an open process in collaboration with our customers."
+        tagline="Planning Labs projects are chosen through an open process in collaboration with our colleagues."
       />
       <div className="grid-container">
         <StickyContainer className="grid-x grid-padding-x">
@@ -57,7 +57,7 @@ const ProcessPage = () => (
           </div>
           <div className="cell large-8" id="page-content">
             <h2 id="step-1">Step 1: Idea Submission</h2>
-            <h6>Customer</h6>
+            <h6>Collaborators</h6>
             <p>
               DCP staff submit a clearly defined problem that needs solving,
               such as a real-world planning issue, a minor technical workflow
@@ -70,10 +70,10 @@ const ProcessPage = () => (
             <hr />
 
             <h2 id="step-2">Step 2: Idea Vetting</h2>
-            <h6> Labs + Customer</h6>
+            <h6> Labs + Collaborators</h6>
             <p>
               When an idea is submitted, the Planning Labs team starts a
-              dialogue with the customer to determine if it’s a good candidate
+              dialogue with our colleagues to determine if it’s a good candidate
               for a Labs project.
             </p>
             <ul>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -111,20 +111,28 @@ class ProjectsPage extends React.Component {
 
     const devCards = () => {
       const devProjects = projects.filter(d => d.type === 'resource');
-      const cards = devProjects.map(project => (
-        <DevCard key={project.slug} project={project} />
-      ));
-
-      return <div>{cards}</div>;
+      
+      if (devProjects.length) {
+        const cards = devProjects.map(project => (
+          <DevCard key={project.slug} project={project} />
+        ));
+        return <div><h3>Developer Resources</h3>{cards}</div>;
+      } else {
+        return null;
+      }
     };
 
     const currentCards = () => {
       const currentProjects = projects.filter(d => d.type === 'current');
-      const cards = currentProjects.map(project => (
-        <DevCard key={project.slug} project={project} />
-      ));
-
-      return <div>{cards}</div>;
+      
+      if (currentProjects.length) {
+        const cards = currentProjects.map(project => (
+          <DevCard key={project.slug} project={project} />
+        ));
+        return <div><h3>In the Works</h3>{cards}</div>;
+      } else {
+        return null;
+      }
     };
 
     const spinner = () => (
@@ -152,7 +160,7 @@ class ProjectsPage extends React.Component {
             <div className="cell large-9">
               <p className="lead">
                 We take on a single project at a time, working closely with our
-                customers from concept to delivery in a matter of weeks. Our
+                colleagues from concept to delivery in a matter of weeks. Our
                 work is open by default, so you can get involved in these
                 projects.
               </p>
@@ -168,10 +176,7 @@ class ProjectsPage extends React.Component {
               {length ? projectCards() : spinner()}
             </div>
             <div className="cell large-4">
-              <h3>In the Works</h3>
               {length ? currentCards() : spinner()}
-
-              <h3>Developer Resources</h3>
               {length ? devCards() : spinner()}
             </div>
           </div>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -111,28 +111,36 @@ class ProjectsPage extends React.Component {
 
     const devCards = () => {
       const devProjects = projects.filter(d => d.type === 'resource');
-      
+
       if (devProjects.length) {
         const cards = devProjects.map(project => (
           <DevCard key={project.slug} project={project} />
         ));
-        return <div><h3>Developer Resources</h3>{cards}</div>;
-      } else {
-        return null;
+        return (
+          <div>
+            <h3>Developer Resources</h3>
+            {cards}
+          </div>
+        );
       }
+      return null;
     };
 
     const currentCards = () => {
       const currentProjects = projects.filter(d => d.type === 'current');
-      
+
       if (currentProjects.length) {
         const cards = currentProjects.map(project => (
           <DevCard key={project.slug} project={project} />
         ));
-        return <div><h3>In the Works</h3>{cards}</div>;
-      } else {
-        return null;
+        return (
+          <div>
+            <h3>In the Works</h3>
+            {cards}
+          </div>
+        );
       }
+      return null;
     };
 
     const spinner = () => (


### PR DESCRIPTION
This PR changes language throughout the site to not use the terms "client" or "customer" to not confuse how we "build with, not for."

Also fixes track.js link. 

Also makes the blog post image conditional so there's no missing img icon when posts have no featured image. 
<img src="https://user-images.githubusercontent.com/409279/56054963-42100f80-5d26-11e9-9a48-0c2bd970e847.png" width=200 />